### PR TITLE
Allow acces to index by index.name.

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2356,6 +2356,8 @@ class NDFrame(PandasObject):
         else:
             if name in self._info_axis:
                 return self[name]
+            if name == self.index.name:
+              return pd.Series(self.index, index=self.index, name=name)
             raise AttributeError("'%s' object has no attribute '%s'" %
                                  (type(self).__name__, name))
 


### PR DESCRIPTION
Work in progress!

The goal of this change would be to ensure the following works:

```
    x = pd.DataFrame({'foo': [1, 2, 3], 'bar': [2, 3, 4]})
    y = x.set_index('foo')
    assert x.foo == y.foo
```
